### PR TITLE
update dsw.owl to have CC0 license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,116 @@
+CC0 1.0 Universal
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator and
+subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the
+purpose of contributing to a commons of creative, cultural and scientific
+works ("Commons") that the public can reliably and without fear of later
+claims of infringement build upon, modify, incorporate in other works, reuse
+and redistribute as freely as possible in any form whatsoever and for any
+purposes, including without limitation commercial purposes. These owners may
+contribute to the Commons to promote the ideal of a free culture and the
+further production of creative, cultural and scientific works, or to gain
+reputation or greater distribution for their Work in part through the use and
+efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation
+of additional consideration or compensation, the person associating CC0 with a
+Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
+and publicly distribute the Work under its terms, with knowledge of his or her
+Copyright and Related Rights in the Work and the meaning and intended legal
+effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not limited
+to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display, communicate,
+  and translate a Work;
+
+  ii. moral rights retained by the original author(s) and/or performer(s);
+
+  iii. publicity and privacy rights pertaining to a person's image or likeness
+  depicted in a Work;
+
+  iv. rights protecting against unfair competition in regards to a Work,
+  subject to the limitations in paragraph 4(a), below;
+
+  v. rights protecting the extraction, dissemination, use and reuse of data in
+  a Work;
+
+  vi. database rights (such as those arising under Directive 96/9/EC of the
+  European Parliament and of the Council of 11 March 1996 on the legal
+  protection of databases, and under any national implementation thereof,
+  including any amended or successor version of such directive); and
+
+  vii. other similar, equivalent or corresponding rights throughout the world
+  based on applicable law or treaty, and any national implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention of,
+applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+and Related Rights and associated claims and causes of action, whether now
+known or unknown (including existing as well as future claims and causes of
+action), in the Work (i) in all territories worldwide, (ii) for the maximum
+duration provided by applicable law or treaty (including future time
+extensions), (iii) in any current or future medium and for any number of
+copies, and (iv) for any purpose whatsoever, including without limitation
+commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+the Waiver for the benefit of each member of the public at large and to the
+detriment of Affirmer's heirs and successors, fully intending that such Waiver
+shall not be subject to revocation, rescission, cancellation, termination, or
+any other legal or equitable action to disrupt the quiet enjoyment of the Work
+by the public as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason be
+judged legally invalid or ineffective under applicable law, then the Waiver
+shall be preserved to the maximum extent permitted taking into account
+Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+is so judged Affirmer hereby grants to each affected person a royalty-free,
+non transferable, non sublicensable, non exclusive, irrevocable and
+unconditional license to exercise Affirmer's Copyright and Related Rights in
+the Work (i) in all territories worldwide, (ii) for the maximum duration
+provided by applicable law or treaty (including future time extensions), (iii)
+in any current or future medium and for any number of copies, and (iv) for any
+purpose whatsoever, including without limitation commercial, advertising or
+promotional purposes (the "License"). The License shall be deemed effective as
+of the date CC0 was applied by Affirmer to the Work. Should any part of the
+License for any reason be judged legally invalid or ineffective under
+applicable law, such partial invalidity or ineffectiveness shall not
+invalidate the remainder of the License, and in such case Affirmer hereby
+affirms that he or she will not (i) exercise any of his or her remaining
+Copyright and Related Rights in the Work or (ii) assert any associated claims
+and causes of action with respect to the Work, in either case contrary to
+Affirmer's express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+  a. No trademark or patent rights held by Affirmer are waived, abandoned,
+  surrendered, licensed or otherwise affected by this document.
+
+  b. Affirmer offers the Work as-is and makes no representations or warranties
+  of any kind concerning the Work, express, implied, statutory or otherwise,
+  including without limitation warranties of title, merchantability, fitness
+  for a particular purpose, non infringement, or the absence of latent or
+  other defects, accuracy, or the present or absence of errors, whether or not
+  discoverable, all to the greatest extent permissible under applicable law.
+
+  c. Affirmer disclaims responsibility for clearing rights of other persons
+  that may apply to the Work or any use thereof, including without limitation
+  any person's Copyright and Related Rights in the Work. Further, Affirmer
+  disclaims responsibility for obtaining any necessary consents, permissions
+  or other rights required for any use of the Work.
+
+  d. Affirmer understands and acknowledges that Creative Commons is not a
+  party to this document and has no duty or obligation with respect to this
+  CC0 or use of the Work.
+
+For more information, please see
+<http://creativecommons.org/publicdomain/zero/1.0/>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # darwin-sw
-The version 1.0 OWL file (in rdf/xml) that is currently served when URIs are dereferenced is at [http://purl.org/dsw/](http://purl.org/dsw/dsw.owl) and in the [1.0 release](https://github.com/darwin-sw/dsw/releases/tag/1.0), http://dx.doi.org/10.5281/zenodo.46972.
+The version 1.0.1 OWL file (in rdf/xml) that is currently served when URIs are dereferenced is at [http://purl.org/dsw/](http://purl.org/dsw/dsw.owl) and in the [1.0.1 release](https://github.com/darwin-sw/dsw/releases/tag/1.0.1), http://dx.doi.org/10.5281/zenodo.46972.
 
-The next version under development (1.1) is [here](https://github.com/darwin-sw/dsw/blob/master/dsw.owl).
+The version 1.0.1 file is [dsw.owl](https://github.com/darwin-sw/dsw/blob/master/dsw.owl).
 
 The Darwin-SW documentation is located in the dsw repository wiki, which can be accessed by [clicking here](https://github.com/darwin-sw/dsw/wiki).
 

--- a/dsw.owl
+++ b/dsw.owl
@@ -1,53 +1,33 @@
 <?xml version="1.0"?>
-
-
-<!DOCTYPE rdf:RDF [
-    <!ENTITY dcterms "http://purl.org/dc/terms/" >
-    <!ENTITY prov "http://www.w3.org/ns/prov#" >
-    <!ENTITY foaf "http://xmlns.com/foaf/0.1/" >
-    <!ENTITY dwciri "http://rs.tdwg.org/dwc/iri/" >
-    <!ENTITY dcmitype "http://purl.org/dc/dcmitype/" >
-    <!ENTITY dwc "http://rs.tdwg.org/dwc/terms/" >
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
-    <!ENTITY dwctype "http://rs.tdwg.org/dwc/dwctype/" >
-    <!ENTITY swrl "http://www.w3.org/2003/11/swrl#" >
-    <!ENTITY dc "http://purl.org/dc/elements/1.1/" >
-    <!ENTITY swrlb "http://www.w3.org/2003/11/swrlb#" >
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
-    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
-    <!ENTITY tc "http://rs.tdwg.org/ontology/voc/TaxonConcept#" >
-    <!ENTITY protege "http://protege.stanford.edu/plugins/owl/protege#" >
-    <!ENTITY xsp "http://www.owl-ontologies.com/2005/08/07/xsp.owl#" >
-]>
-
-
 <rdf:RDF xmlns="http://purl.org/dsw/"
      xml:base="http://purl.org/dsw/"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:prov="http://www.w3.org/ns/prov#"
-     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
-     xmlns:foaf="http://xmlns.com/foaf/0.1/"
-     xmlns:dwciri="http://rs.tdwg.org/dwc/iri/"
-     xmlns:xsp="http://www.owl-ontologies.com/2005/08/07/xsp.owl#"
-     xmlns:dwc="http://rs.tdwg.org/dwc/terms/"
-     xmlns:dcmitype="http://purl.org/dc/dcmitype/"
-     xmlns:dcterms="http://purl.org/dc/terms/"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:dwctype="http://rs.tdwg.org/dwc/dwctype/"
-     xmlns:swrl="http://www.w3.org/2003/11/swrl#"
      xmlns:tc="http://rs.tdwg.org/ontology/voc/TaxonConcept#"
-     xmlns:swrlb="http://www.w3.org/2003/11/swrlb#"
+     xmlns:dwc="http://rs.tdwg.org/dwc/terms/"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+     xmlns:xsp="http://www.owl-ontologies.com/2005/08/07/xsp.owl#"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:prov="http://www.w3.org/ns/prov#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:swrl="http://www.w3.org/2003/11/swrl#"
+     xmlns:swrlb="http://www.w3.org/2003/11/swrlb#"
+     xmlns:dwciri="http://rs.tdwg.org/dwc/iri/"
+     xmlns:dcterms="http://purl.org/dc/terms/"
+     xmlns:dwctype="http://rs.tdwg.org/dwc/dwctype/"
+     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
+     xmlns:dcmitype="http://purl.org/dc/dcmitype/">
     <owl:Ontology rdf:about="http://purl.org/dsw/">
-        <dc:description>Changes from version 0.3 to 0.4 change DwC class namespace from dwctype: to dwc: to follow class proposal, removed references to TDWG TaxonConcept ontology; deprecated terms that now have equivalent terms in Darwin Core.</dc:description>
-        <rdfs:comment>Darwin Semantic Web, version 1.0 . Please see https://github.com/darwin-sw/ for full details</rdfs:comment>
-        <owl:versionInfo>1.0</owl:versionInfo>
-        <dc:description>Changes from version 0.2.1 to version 0.3: removal of all functional and inverse function properties of object property terms, use of dwctype classes, deprecation of terms replaced by dwciri: terms, removal of references to TDWG Ontology.</dc:description>
-        <dc:description>Version 0.4 to 1.0 fixed reversed dsw:locates and dsw:locatedAt. Added labels. Changed comments and descriptions to conform to DC and DwC precedent.  Added subClassOf relations to RO hasEvidence and isEvidenceFor.  Specified preferred direction for inverse object property pairs.</dc:description>
         <dc:creator>Steve Baskauf &amp; Cam Webb</dc:creator>
+        <dc:description>Change from version 1.0 to 1.0.1 Add CC0 license.</dc:description>
+        <dc:description>Changes from version 0.2.1 to version 0.3: removal of all functional and inverse function properties of object property terms, use of dwctype classes, deprecation of terms replaced by dwciri: terms, removal of references to TDWG Ontology.</dc:description>
+        <dc:description>Changes from version 0.3 to 0.4 change DwC class namespace from dwctype: to dwc: to follow class proposal, removed references to TDWG TaxonConcept ontology; deprecated terms that now have equivalent terms in Darwin Core.</dc:description>
+        <dc:description>Version 0.4 to 1.0 fixed reversed dsw:locates and dsw:locatedAt. Added labels. Changed comments and descriptions to conform to DC and DwC precedent.  Added subClassOf relations to RO hasEvidence and isEvidenceFor.  Specified preferred direction for inverse object property pairs.</dc:description>
+        <dcterms:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+        <rdfs:comment>Darwin Semantic Web, version 1.0 . Please see https://github.com/darwin-sw/ for full details</rdfs:comment>
+        <owl:versionInfo>1.0.1</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -65,37 +45,43 @@
 
     <!-- http://purl.org/dc/elements/1.1/creator -->
 
-    <owl:AnnotationProperty rdf:about="&dc;creator"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/creator"/>
     
 
 
     <!-- http://purl.org/dc/elements/1.1/date -->
 
-    <owl:AnnotationProperty rdf:about="&dc;date"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
     
 
 
     <!-- http://purl.org/dc/elements/1.1/description -->
 
-    <owl:AnnotationProperty rdf:about="&dc;description"/>
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/description"/>
+    
+
+
+    <!-- http://purl.org/dc/terms/license -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/license"/>
     
 
 
     <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
 
-    <owl:AnnotationProperty rdf:about="&rdfs;comment"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#comment"/>
     
 
 
     <!-- http://www.w3.org/2002/07/owl#versionInfo -->
 
-    <owl:AnnotationProperty rdf:about="&owl;versionInfo"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2002/07/owl#versionInfo"/>
     
 
 
     <!-- http://www.w3.org/ns/prov#inverse -->
 
-    <owl:AnnotationProperty rdf:about="&prov;inverse"/>
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#inverse"/>
     
 
 
@@ -112,7 +98,7 @@
 
     <!-- http://www.w3.org/2001/XMLSchema#date -->
 
-    <rdfs:Datatype rdf:about="&xsd;date"/>
+    <rdfs:Datatype rdf:about="http://www.w3.org/2001/XMLSchema#date"/>
     
 
 
@@ -146,15 +132,16 @@
     <!-- http://purl.org/dsw/atEvent -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/atEvent">
-        <rdfs:label xml:lang="en">At Event</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.org/dsw/eventOf"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Event"/>
         <dc:creator>Steve Baskauf</dc:creator>
-        <prov:inverse>eventOf</prov:inverse>
-        <rdfs:comment xml:lang="en">Links a subject Occurrence instance to an object Event instance.</rdfs:comment>
         <dc:description xml:lang="en">The atEvent relationship is many-to-one (many occurrences at one event)</dc:description>
         <dc:description xml:lang="en">This property is preferred over its inverse if the link is made in only one direction.</dc:description>
+        <rdfs:comment xml:lang="en">Links a subject Occurrence instance to an object Event instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <rdfs:range rdf:resource="&dwc;Event"/>
-        <rdfs:domain rdf:resource="&dwc;Occurrence"/>
+        <rdfs:label xml:lang="en">At Event</rdfs:label>
+        <prov:inverse>eventOf</prov:inverse>
     </owl:ObjectProperty>
     
 
@@ -162,14 +149,15 @@
     <!-- http://purl.org/dsw/derivedFrom -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/derivedFrom">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">Derived From</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.org/dsw/hasDerivative"/>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <dc:creator>Steve Baskauf</dc:creator>
         <dc:description xml:lang="en">Range can be IndividualOrganism or another Specimen </dc:description>
         <dc:description xml:lang="en">This property is preferred over its inverse if the link is made in only one direction.</dc:description>
-        <prov:inverse>hasDerivative</prov:inverse>
-        <dc:creator>Steve Baskauf</dc:creator>
         <rdfs:comment xml:lang="en">Links a subject Token instance to an object instance of another Token or an Organism.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Derived From</rdfs:label>
+        <prov:inverse>hasDerivative</prov:inverse>
     </owl:ObjectProperty>
     
 
@@ -177,15 +165,14 @@
     <!-- http://purl.org/dsw/eventOf -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/eventOf">
-        <rdfs:label xml:lang="en">Event Of</rdfs:label>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Event"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
         <dc:creator>Steve Baskauf</dc:creator>
-        <rdfs:comment xml:lang="en">Links a subject Event instance to an object Occurrence instance.</rdfs:comment>
         <dc:description xml:lang="en">The eventOf relationship is one-to-many (one event has many occurrences)</dc:description>
         <dc:description xml:lang="en">Use the inverse property dsw:atEvent in preference to this one if the link is made in only one direction.</dc:description>
+        <rdfs:comment xml:lang="en">Links a subject Event instance to an object Occurrence instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:inverseOf rdf:resource="http://purl.org/dsw/atEvent"/>
-        <rdfs:domain rdf:resource="&dwc;Event"/>
-        <rdfs:range rdf:resource="&dwc;Occurrence"/>
+        <rdfs:label xml:lang="en">Event Of</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -193,16 +180,17 @@
     <!-- http://purl.org/dsw/evidenceFor -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/evidenceFor">
-        <rdfs:label xml:lang="en">Evidence For</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002472"/>
+        <owl:inverseOf rdf:resource="http://purl.org/dsw/hasEvidence"/>
+        <rdfs:domain rdf:resource="http://purl.org/dsw/Token"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
         <dc:creator>Cam Webb</dc:creator>
         <dc:description xml:lang="en">In most cases this will act like a functional property (only possibly documenting a single occurrence), but some images may document several occurrences, so the formal specification of functional property is omitted.</dc:description>
-        <rdfs:comment xml:lang="en">Links a subject Token instance to an object Occurrence instance.</rdfs:comment>
         <dc:description xml:lang="en">This property is preferred over its inverse if the link is made in only one direction.</dc:description>
-        <prov:inverse>hasEvidence</prov:inverse>
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002472"/>
+        <rdfs:comment xml:lang="en">Links a subject Token instance to an object Occurrence instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <rdfs:domain rdf:resource="http://purl.org/dsw/Token"/>
-        <rdfs:range rdf:resource="&dwc;Occurrence"/>
+        <rdfs:label xml:lang="en">Evidence For</rdfs:label>
+        <prov:inverse>hasEvidence</prov:inverse>
     </owl:ObjectProperty>
     
 
@@ -210,13 +198,13 @@
     <!-- http://purl.org/dsw/georefBy -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/georefBy">
-        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+        <owl:equivalentProperty rdf:resource="http://rs.tdwg.org/dwc/iri/georeferencedBy"/>
+        <rdfs:domain rdf:resource="http://purl.org/dc/terms/Location"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <dc:creator>Steve Baskauf</dc:creator>
         <dc:description xml:lang="en">Was georeferenceByURI; deprecated 2014-11-21 to be replaced by dwciri:georeferencedBy</dc:description>
-        <rdfs:domain rdf:resource="&dcterms;Location"/>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:equivalentProperty rdf:resource="&dwciri;georeferencedBy"/>
-        <rdfs:range rdf:resource="&foaf;Agent"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -224,13 +212,12 @@
     <!-- http://purl.org/dsw/hasDerivative -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/hasDerivative">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:label xml:lang="en">Has Derivative</rdfs:label>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <dc:creator>Steve Baskauf</dc:creator>
-        <rdfs:comment xml:lang="en">Links a subject Organism or Token instance to an object Token instance.</rdfs:comment>
         <dc:description xml:lang="en">Use the inverse property dsw:derivedFrom in preference to this one if the link is made in only one direction.</dc:description>
+        <rdfs:comment xml:lang="en">Links a subject Organism or Token instance to an object Token instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:inverseOf rdf:resource="http://purl.org/dsw/derivedFrom"/>
+        <rdfs:label xml:lang="en">Has Derivative</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -238,15 +225,14 @@
     <!-- http://purl.org/dsw/hasEvidence -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/hasEvidence">
-        <rdfs:label xml:lang="en">Has Evidence</rdfs:label>
-        <dc:creator>Cam Webb</dc:creator>
-        <rdfs:comment xml:lang="en">Links a subject Occurrence instance to an object Token instance.</rdfs:comment>
-        <dc:description xml:lang="en">Use the inverse property dsw:evidenceFor in preference to this one if the link is made in only one direction.</dc:description>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002558"/>
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
         <rdfs:range rdf:resource="http://purl.org/dsw/Token"/>
-        <owl:inverseOf rdf:resource="http://purl.org/dsw/evidenceFor"/>
-        <rdfs:domain rdf:resource="&dwc;Occurrence"/>
+        <dc:creator>Cam Webb</dc:creator>
+        <dc:description xml:lang="en">Use the inverse property dsw:evidenceFor in preference to this one if the link is made in only one direction.</dc:description>
+        <rdfs:comment xml:lang="en">Links a subject Occurrence instance to an object Token instance.</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Has Evidence</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -254,15 +240,15 @@
     <!-- http://purl.org/dsw/hasIdentification -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/hasIdentification">
-        <rdfs:label xml:lang="en">Has Identification</rdfs:label>
-        <rdfs:comment xml:lang="en">Links a subject Organism instance to an object Identification instance.</rdfs:comment>
+        <owl:inverseOf rdf:resource="http://purl.org/dsw/identifies"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
         <dc:creator>Steve Baskauf, name changed by Cam Webb</dc:creator>
         <dc:description xml:lang="en">The hasIdentification relationship is one-to-many (one individual organism has many identifications)</dc:description>
         <dc:description xml:lang="en">Use the inverse property dsw:identifies in preference to this one if the link is made in only one direction.</dc:description>
+        <rdfs:comment xml:lang="en">Links a subject Organism instance to an object Identification instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:inverseOf rdf:resource="http://purl.org/dsw/identifies"/>
-        <rdfs:range rdf:resource="&dwc;Identification"/>
-        <rdfs:domain rdf:resource="&dwc;Organism"/>
+        <rdfs:label xml:lang="en">Has Identification</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -270,15 +256,15 @@
     <!-- http://purl.org/dsw/hasOccurrence -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/hasOccurrence">
-        <rdfs:label xml:lang="en">Has Occurrence</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.org/dsw/occurrenceOf"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
         <dc:creator>Steve Baskauf, name changed by Cam Webb</dc:creator>
-        <rdfs:comment xml:lang="en">Links a subject Organism instance to an object Occurrence instance.</rdfs:comment>
         <dc:description xml:lang="en">The hasOccurrence relationship is one-to-many (one individual organism may have many occurrences)</dc:description>
         <dc:description xml:lang="en">Use the inverse property dsw:occurrenceOf in preference to this one if the link is made in only one direction.</dc:description>
+        <rdfs:comment xml:lang="en">Links a subject Organism instance to an object Occurrence instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:inverseOf rdf:resource="http://purl.org/dsw/occurrenceOf"/>
-        <rdfs:range rdf:resource="&dwc;Occurrence"/>
-        <rdfs:domain rdf:resource="&dwc;Organism"/>
+        <rdfs:label xml:lang="en">Has Occurrence</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -286,17 +272,17 @@
     <!-- http://purl.org/dsw/idBasedOn -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/idBasedOn">
-        <rdfs:label xml:lang="en">ID Based On</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002558"/>
+        <owl:inverseOf rdf:resource="http://purl.org/dsw/isBasisForId"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <rdfs:range rdf:resource="http://purl.org/dsw/Token"/>
         <dc:creator>Steve Baskauf</dc:creator>
         <dc:date>2011-01-27</dc:date>
-        <rdfs:comment xml:lang="en">Links a subject Identification instance to an object Token instance.</rdfs:comment>
         <dc:description xml:lang="en">The subject identification was in part based on the object token. Was identifiedBasedOn</dc:description>
         <dc:description xml:lang="en">Use the inverse property dsw:isBasisForId in preference to this one if the link is made in only one direction.</dc:description>
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002558"/>
+        <rdfs:comment xml:lang="en">Links a subject Identification instance to an object Token instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <rdfs:range rdf:resource="http://purl.org/dsw/Token"/>
-        <owl:inverseOf rdf:resource="http://purl.org/dsw/isBasisForId"/>
-        <rdfs:domain rdf:resource="&dwc;Identification"/>
+        <rdfs:label xml:lang="en">ID Based On</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -304,13 +290,13 @@
     <!-- http://purl.org/dsw/idBy -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/idBy">
-        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+        <owl:equivalentProperty rdf:resource="http://rs.tdwg.org/dwc/iri/identifiedBy"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <dc:creator>Steve Baskauf</dc:creator>
         <dc:description xml:lang="en">was dsw:identificationByURI; deprecated 2014-11-21 to be replaced by dwciri:identifiedBy</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:equivalentProperty rdf:resource="&dwciri;identifiedBy"/>
-        <rdfs:domain rdf:resource="&dwc;Identification"/>
-        <rdfs:range rdf:resource="&foaf;Agent"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -318,15 +304,15 @@
     <!-- http://purl.org/dsw/identifies -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/identifies">
-        <rdfs:label xml:lang="en">Identifies</rdfs:label>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
         <dc:creator>Steve Baskauf</dc:creator>
-        <rdfs:comment xml:lang="en">Links a subject Identification instance to an object Organism instance.</rdfs:comment>
         <dc:description xml:lang="en">The identifies relationship is many-to-one (many identifications for one individual organism)</dc:description>
         <dc:description xml:lang="en">This property is preferred over its inverse if the link is made in only one direction.</dc:description>
-        <prov:inverse>hasIdentification</prov:inverse>
+        <rdfs:comment xml:lang="en">Links a subject Identification instance to an object Organism instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <rdfs:domain rdf:resource="&dwc;Identification"/>
-        <rdfs:range rdf:resource="&dwc;Organism"/>
+        <rdfs:label xml:lang="en">Identifies</rdfs:label>
+        <prov:inverse>hasIdentification</prov:inverse>
     </owl:ObjectProperty>
     
 
@@ -334,17 +320,17 @@
     <!-- http://purl.org/dsw/isBasisForId -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/isBasisForId">
-        <rdfs:label xml:lang="en">Is Basis For ID</rdfs:label>
-        <prov:inverse>idBasedOn</prov:inverse>
-        <dc:date>2011-01-27</dc:date>
-        <rdfs:comment xml:lang="en">Links a subject Token instance to an object Identification instance.</rdfs:comment>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002472"/>
+        <rdfs:domain rdf:resource="http://purl.org/dsw/Token"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
         <dc:creator>Steve Baskauf</dc:creator>
+        <dc:date>2011-01-27</dc:date>
         <dc:description xml:lang="en">The subject resource is a basis on which the object identification is made.</dc:description>
         <dc:description xml:lang="en">This property is preferred over its inverse if the link is made in only one direction.</dc:description>
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0002472"/>
+        <rdfs:comment xml:lang="en">Links a subject Token instance to an object Identification instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <rdfs:domain rdf:resource="http://purl.org/dsw/Token"/>
-        <rdfs:range rdf:resource="&dwc;Identification"/>
+        <rdfs:label xml:lang="en">Is Basis For ID</rdfs:label>
+        <prov:inverse>idBasedOn</prov:inverse>
     </owl:ObjectProperty>
     
 
@@ -352,15 +338,16 @@
     <!-- http://purl.org/dsw/locatedAt -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/locatedAt">
-        <rdfs:label xml:lang="en">Located At</rdfs:label>
+        <owl:inverseOf rdf:resource="http://purl.org/dsw/locates"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Event"/>
+        <rdfs:range rdf:resource="http://purl.org/dc/terms/Location"/>
         <dc:creator>Cam Webb</dc:creator>
-        <rdfs:comment xml:lang="en">Links a subject Event instance to an object Location instance.</rdfs:comment>
-        <dc:description xml:lang="en">This property is preferred over its inverse if the link is made in only one direction.</dc:description>
-        <prov:inverse>locates</prov:inverse>
         <dc:description xml:lang="en">The locatedAt relationship is many-to-one (many events at one location)</dc:description>
-        <rdfs:range rdf:resource="&dcterms;Location"/>
+        <dc:description xml:lang="en">This property is preferred over its inverse if the link is made in only one direction.</dc:description>
+        <rdfs:comment xml:lang="en">Links a subject Event instance to an object Location instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <rdfs:domain rdf:resource="&dwc;Event"/>
+        <rdfs:label xml:lang="en">Located At</rdfs:label>
+        <prov:inverse>locates</prov:inverse>
     </owl:ObjectProperty>
     
 
@@ -368,15 +355,14 @@
     <!-- http://purl.org/dsw/locates -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/locates">
-        <rdfs:label xml:lang="en">Locates</rdfs:label>
+        <rdfs:domain rdf:resource="http://purl.org/dc/terms/Location"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Event"/>
         <dc:creator>Cam Webb</dc:creator>
-        <rdfs:comment xml:lang="en">Links a subject Event instance to an object Locatino instance.</rdfs:comment>
         <dc:description xml:lang="en">The locates relationship is one to many (one location may have many events)</dc:description>
         <dc:description xml:lang="en">Use the inverse property dsw:locatedAt in preference to this one if the link is made in only one direction.</dc:description>
-        <rdfs:domain rdf:resource="&dcterms;Location"/>
+        <rdfs:comment xml:lang="en">Links a subject Event instance to an object Locatino instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:inverseOf rdf:resource="http://purl.org/dsw/locatedAt"/>
-        <rdfs:range rdf:resource="&dwc;Event"/>
+        <rdfs:label xml:lang="en">Locates</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -384,15 +370,15 @@
     <!-- http://purl.org/dsw/occurrenceOf -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/occurrenceOf">
-        <rdfs:label xml:lang="en">Occurrence Of</rdfs:label>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
         <dc:creator>Steve Baskauf, name changed by Cam Webb</dc:creator>
-        <rdfs:comment xml:lang="en">Links a subject Occurrence instance to an object Organism instance.</rdfs:comment>
-        <prov:inverse>hasOccurrence</prov:inverse>
         <dc:description xml:lang="en">The occurrrenceOf relationship is many-to-one (many occurrences for one individual organism)</dc:description>
         <dc:description xml:lang="en">This property is preferred over its inverse if the link is made in only one direction.</dc:description>
+        <rdfs:comment xml:lang="en">Links a subject Occurrence instance to an object Organism instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <rdfs:domain rdf:resource="&dwc;Occurrence"/>
-        <rdfs:range rdf:resource="&dwc;Organism"/>
+        <rdfs:label xml:lang="en">Occurrence Of</rdfs:label>
+        <prov:inverse>hasOccurrence</prov:inverse>
     </owl:ObjectProperty>
     
 
@@ -400,12 +386,12 @@
     <!-- http://purl.org/dsw/recBy -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/recBy">
-        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+        <owl:equivalentProperty rdf:resource="http://rs.tdwg.org/dwc/iri/recordedBy"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <dc:description xml:lang="en">Deprecated 2014-11-21 to be replaced by dwciri:recordedBy</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:equivalentProperty rdf:resource="&dwciri;recordedBy"/>
-        <rdfs:domain rdf:resource="&dwc;Occurrence"/>
-        <rdfs:range rdf:resource="&foaf;Agent"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
@@ -413,15 +399,15 @@
     <!-- http://purl.org/dsw/taxonOfId -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/taxonOfId">
-        <rdfs:label xml:lang="en">Taxon Of ID</rdfs:label>
-        <rdfs:comment xml:lang="en">Links a subject Taxon instance to an object Identification instance.</rdfs:comment>
+        <owl:inverseOf rdf:resource="http://rs.tdwg.org/dwc/iri/toTaxon"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Taxon"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
         <dc:creator>Steve Baskauf, name changed by Cam Webb</dc:creator>
         <dc:description xml:lang="en">The taxonOfID relationship is one-to-many (one taxon may be referenced in many identifications)</dc:description>
         <dc:description xml:lang="en">Use the well-known dwciri:toTaxon predicate in preference to this one if the link is only made in one direction.</dc:description>
+        <rdfs:comment xml:lang="en">Links a subject Taxon instance to an object Identification instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:inverseOf rdf:resource="&dwciri;toTaxon"/>
-        <rdfs:range rdf:resource="&dwc;Identification"/>
-        <rdfs:domain rdf:resource="&dwc;Taxon"/>
+        <rdfs:label xml:lang="en">Taxon Of ID</rdfs:label>
     </owl:ObjectProperty>
     
 
@@ -429,70 +415,70 @@
     <!-- http://purl.org/dsw/toTaxon -->
 
     <owl:ObjectProperty rdf:about="http://purl.org/dsw/toTaxon">
-        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+        <owl:equivalentProperty rdf:resource="http://rs.tdwg.org/dwc/iri/toTaxon"/>
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
         <dc:creator>Steve Baskauf, name changed by Cam Webb</dc:creator>
         <dc:description xml:lang="en">The toTaxon relationship is many-to-one (many identifications can reference one taxon).  This property should link to a taxon concept (i.e. Taxon name plus Authority) URI, such as: http://biodiversity.org.au/apni.taxon/118883 ; deprecated 2014-11-21 to be replaced by dwciri:toTaxon</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
-        <owl:equivalentProperty rdf:resource="&dwciri;toTaxon"/>
-        <rdfs:domain rdf:resource="&dwc;Identification"/>
-        <rdfs:range rdf:resource="&tc;TaxonConcept"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
 
 
     <!-- http://rs.tdwg.org/dwc/iri/georeferencedBy -->
 
-    <owl:ObjectProperty rdf:about="&dwciri;georeferencedBy">
-        <rdfs:label xml:lang="en">Georeferenced By</rdfs:label>
+    <owl:ObjectProperty rdf:about="http://rs.tdwg.org/dwc/iri/georeferencedBy">
+        <rdfs:domain rdf:resource="http://purl.org/dc/terms/Location"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <rdfs:comment xml:lang="en">Links a subject Location instance to an object Agent instance that did the georeferencing.</rdfs:comment>
-        <rdfs:domain rdf:resource="&dcterms;Location"/>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/iri/"/>
-        <rdfs:range rdf:resource="&foaf;Agent"/>
+        <rdfs:label xml:lang="en">Georeferenced By</rdfs:label>
     </owl:ObjectProperty>
     
 
 
     <!-- http://rs.tdwg.org/dwc/iri/identifiedBy -->
 
-    <owl:ObjectProperty rdf:about="&dwciri;identifiedBy">
-        <rdfs:label xml:lang="en">Identified By</rdfs:label>
+    <owl:ObjectProperty rdf:about="http://rs.tdwg.org/dwc/iri/identifiedBy">
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <dc:description xml:lang="en">Definition based on dwc:identifiedBy but modified to make it appropriate for non-literal values.</dc:description>
         <rdfs:comment xml:lang="en">People, groups, or organizations who assigned the Taxon to the subject</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/iri/"/>
-        <rdfs:domain rdf:resource="&dwc;Identification"/>
-        <rdfs:range rdf:resource="&foaf;Agent"/>
+        <rdfs:label xml:lang="en">Identified By</rdfs:label>
     </owl:ObjectProperty>
     
 
 
     <!-- http://rs.tdwg.org/dwc/iri/recordedBy -->
 
-    <owl:ObjectProperty rdf:about="&dwciri;recordedBy">
-        <rdfs:label xml:lang="en">Recorded By</rdfs:label>
+    <owl:ObjectProperty rdf:about="http://rs.tdwg.org/dwc/iri/recordedBy">
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
+        <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <dc:description xml:lang="en">Definition based on dwc:recordedBy but modified to make it appropriate for non-literal objects.</dc:description>
         <rdfs:comment xml:lang="en">People, groups, or organizations responsible for recording the original Occurrence.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/iri/"/>
-        <rdfs:domain rdf:resource="&dwc;Occurrence"/>
-        <rdfs:range rdf:resource="&foaf;Agent"/>
+        <rdfs:label xml:lang="en">Recorded By</rdfs:label>
     </owl:ObjectProperty>
     
 
 
     <!-- http://rs.tdwg.org/dwc/iri/toTaxon -->
 
-    <owl:ObjectProperty rdf:about="&dwciri;toTaxon">
-        <rdfs:label xml:lang="en">To Taxon</rdfs:label>
+    <owl:ObjectProperty rdf:about="http://rs.tdwg.org/dwc/iri/toTaxon">
+        <rdfs:domain rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <rdfs:range rdf:resource="http://rs.tdwg.org/dwc/terms/Taxon"/>
         <rdfs:comment xml:lang="en">Links a subject Identification instance to an object Taxon instance.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/iri/"/>
-        <rdfs:domain rdf:resource="&dwc;Identification"/>
-        <rdfs:range rdf:resource="&dwc;Taxon"/>
+        <rdfs:label xml:lang="en">To Taxon</rdfs:label>
     </owl:ObjectProperty>
     
 
 
     <!-- http://www.w3.org/2002/07/owl#topObjectProperty -->
 
-    <owl:ObjectProperty rdf:about="&owl;topObjectProperty"/>
+    <owl:ObjectProperty rdf:about="http://www.w3.org/2002/07/owl#topObjectProperty"/>
     
 
 
@@ -510,18 +496,18 @@
     <!-- http://purl.org/dsw/individualOrganismRemarks -->
 
     <owl:DatatypeProperty rdf:about="http://purl.org/dsw/individualOrganismRemarks">
-        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-        <dc:description xml:lang="en">Deprecated in favor of dwc:organismRemarks on 2014-11-21.</dc:description>
-        <dc:creator>Steve Baskauf</dc:creator>
-        <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
         <rdfs:domain rdf:resource="http://purl.org/dsw/IndividualOrganism"/>
+        <dc:creator>Steve Baskauf</dc:creator>
+        <dc:description xml:lang="en">Deprecated in favor of dwc:organismRemarks on 2014-11-21.</dc:description>
+        <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     
 
 
     <!-- http://www.w3.org/2002/07/owl#topDataProperty -->
 
-    <owl:DatatypeProperty rdf:about="&owl;topDataProperty"/>
+    <owl:DatatypeProperty rdf:about="http://www.w3.org/2002/07/owl#topDataProperty"/>
     
 
 
@@ -538,21 +524,21 @@
 
     <!-- http://purl.org/dc/terms/Location -->
 
-    <owl:Class rdf:about="&dcterms;Location">
-        <rdfs:label xml:lang="en">Location</rdfs:label>
+    <owl:Class rdf:about="http://purl.org/dc/terms/Location">
         <owl:disjointWith rdf:resource="http://purl.org/dsw/Specimen"/>
         <owl:disjointWith rdf:resource="http://purl.org/dsw/Token"/>
-        <owl:disjointWith rdf:resource="&dwc;Event"/>
-        <owl:disjointWith rdf:resource="&dwc;Identification"/>
-        <owl:disjointWith rdf:resource="&dwc;Occurrence"/>
-        <owl:disjointWith rdf:resource="&dwc;Organism"/>
-        <owl:disjointWith rdf:resource="&dwc;Taxon"/>
-        <owl:disjointWith rdf:resource="&tc;TaxonConcept"/>
-        <owl:disjointWith rdf:resource="&foaf;Agent"/>
-        <owl:disjointWith rdf:resource="&foaf;Document"/>
-        <rdfs:comment xml:lang="en">A spatial region or named place.</rdfs:comment>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Event"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Taxon"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <dc:description xml:lang="en">Definition taken from Dublin Core vocabulary 2014-11-21.</dc:description>
+        <rdfs:comment xml:lang="en">A spatial region or named place.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dc/terms/"/>
+        <rdfs:label xml:lang="en">Location</rdfs:label>
     </owl:Class>
     
 
@@ -560,10 +546,10 @@
     <!-- http://purl.org/dsw/DriedSpecimen -->
 
     <owl:Class rdf:about="http://purl.org/dsw/DriedSpecimen">
-        <rdfs:label xml:lang="en">Dried Specimen</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&dwc;PreservedSpecimen"/>
+        <rdfs:subClassOf rdf:resource="http://rs.tdwg.org/dwc/terms/PreservedSpecimen"/>
         <rdfs:comment xml:lang="en">A specimen preserved by drying.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Dried Specimen</rdfs:label>
     </owl:Class>
     
 
@@ -571,11 +557,11 @@
     <!-- http://purl.org/dsw/IndividualOrganism -->
 
     <owl:Class rdf:about="http://purl.org/dsw/IndividualOrganism">
-        <owl:equivalentClass rdf:resource="&dwc;Organism"/>
-        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
-        <rdfs:comment xml:lang="en">A particular organism or defined group of organisms considered to be taxonomically homogeneous.  Instances of the Organism class are intended to facilitate linking of one or more Identification instances to one or more Occurrence instances.  Therefore, things that are typically assigned scientific names (such as viruses, hybrids, and lichens) and aggregates whose occurrences are typically recorded (such as packs, clones, and colonies) are included in the scope of this class.</rdfs:comment>
+        <owl:equivalentClass rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
         <dc:description xml:lang="en">This class is equivalent to the more well-known Darwin Core class dwc:Organism.  It was deprecated following the addition of dwc:Organism to Darwin Core on 2014-10-26.  </dc:description>
+        <rdfs:comment xml:lang="en">A particular organism or defined group of organisms considered to be taxonomically homogeneous.  Instances of the Organism class are intended to facilitate linking of one or more Identification instances to one or more Occurrence instances.  Therefore, things that are typically assigned scientific names (such as viruses, hybrids, and lichens) and aggregates whose occurrences are typically recorded (such as packs, clones, and colonies) are included in the scope of this class.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -583,11 +569,11 @@
     <!-- http://purl.org/dsw/LivingSpecimen -->
 
     <owl:Class rdf:about="http://purl.org/dsw/LivingSpecimen">
-        <owl:equivalentClass rdf:resource="&dwc;LivingSpecimen"/>
+        <owl:equivalentClass rdf:resource="http://rs.tdwg.org/dwc/terms/LivingSpecimen"/>
         <rdfs:subClassOf rdf:resource="http://purl.org/dsw/Specimen"/>
-        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
         <dc:description xml:lang="en">Deprecated in favor of the Darwin Core class dwc:LivingSpecimen.</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -596,9 +582,9 @@
 
     <owl:Class rdf:about="http://purl.org/dsw/PreservedSpecimen">
         <rdfs:subClassOf rdf:resource="http://purl.org/dsw/Specimen"/>
-        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
         <dc:description xml:lang="en">Deprecated in favor of the Darwin Core class dwc:PreservedSpecimen.</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -606,15 +592,15 @@
     <!-- http://purl.org/dsw/Specimen -->
 
     <owl:Class rdf:about="http://purl.org/dsw/Specimen">
-        <rdfs:label xml:lang="en">Specimen</rdfs:label>
-        <owl:disjointWith rdf:resource="&dwc;Event"/>
-        <owl:disjointWith rdf:resource="&dwc;Identification"/>
-        <owl:disjointWith rdf:resource="&dwc;Occurrence"/>
-        <owl:disjointWith rdf:resource="&dwc;Taxon"/>
-        <owl:disjointWith rdf:resource="&tc;TaxonConcept"/>
-        <owl:disjointWith rdf:resource="&foaf;Agent"/>
-        <owl:disjointWith rdf:resource="&foaf;Document"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Event"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Taxon"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Specimen</rdfs:label>
     </owl:Class>
     
 
@@ -622,10 +608,10 @@
     <!-- http://purl.org/dsw/SpecimenInAlcohol -->
 
     <owl:Class rdf:about="http://purl.org/dsw/SpecimenInAlcohol">
-        <rdfs:label xml:lang="en">Specimen In Alcohol</rdfs:label>
-        <rdfs:subClassOf rdf:resource="&dwc;PreservedSpecimen"/>
+        <rdfs:subClassOf rdf:resource="http://rs.tdwg.org/dwc/terms/PreservedSpecimen"/>
         <rdfs:comment xml:lang="en">A specimen preserved in alcohol.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Specimen In Alcohol</rdfs:label>
     </owl:Class>
     
 
@@ -633,162 +619,162 @@
     <!-- http://purl.org/dsw/Token -->
 
     <owl:Class rdf:about="http://purl.org/dsw/Token">
-        <rdfs:label xml:lang="en">Token</rdfs:label>
-        <owl:disjointWith rdf:resource="&dwc;Event"/>
-        <owl:disjointWith rdf:resource="&dwc;Identification"/>
-        <owl:disjointWith rdf:resource="&dwc;Occurrence"/>
-        <owl:disjointWith rdf:resource="&dwc;Taxon"/>
-        <owl:disjointWith rdf:resource="&tc;TaxonConcept"/>
-        <owl:disjointWith rdf:resource="&foaf;Agent"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Event"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Taxon"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <rdfs:comment xml:lang="en">A form of evidence derived from a dwc:Organism.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Token</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://rs.tdwg.org/dwc/terms/Event -->
 
-    <owl:Class rdf:about="&dwc;Event">
-        <rdfs:label xml:lang="en">Event</rdfs:label>
-        <owl:disjointWith rdf:resource="&dwc;Identification"/>
-        <owl:disjointWith rdf:resource="&dwc;Occurrence"/>
-        <owl:disjointWith rdf:resource="&dwc;Organism"/>
-        <owl:disjointWith rdf:resource="&dwc;Taxon"/>
-        <owl:disjointWith rdf:resource="&tc;TaxonConcept"/>
-        <owl:disjointWith rdf:resource="&foaf;Agent"/>
-        <owl:disjointWith rdf:resource="&foaf;Document"/>
-        <rdfs:comment xml:lang="en">An action that occurs at some location during some time.</rdfs:comment>
+    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/Event">
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Identification"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Taxon"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <dc:description xml:lang="en">Definition taken from Darwin Core vocabulary 2014-11-21.</dc:description>
+        <rdfs:comment xml:lang="en">An action that occurs at some location during some time.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/terms/"/>
+        <rdfs:label xml:lang="en">Event</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://rs.tdwg.org/dwc/terms/Identification -->
 
-    <owl:Class rdf:about="&dwc;Identification">
-        <rdfs:label xml:lang="en">Identification</rdfs:label>
-        <owl:disjointWith rdf:resource="&dwc;Occurrence"/>
-        <owl:disjointWith rdf:resource="&dwc;Organism"/>
-        <owl:disjointWith rdf:resource="&dwc;Taxon"/>
-        <owl:disjointWith rdf:resource="&tc;TaxonConcept"/>
-        <owl:disjointWith rdf:resource="&foaf;Agent"/>
-        <owl:disjointWith rdf:resource="&foaf;Document"/>
-        <rdfs:comment xml:lang="en">A taxonomic determination (e.g., the assignment to a taxon).</rdfs:comment>
+    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/Identification">
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Occurrence"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Taxon"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <dc:description xml:lang="en">Definition taken from Darwin Core vocabulary 2014-11-21.</dc:description>
+        <rdfs:comment xml:lang="en">A taxonomic determination (e.g., the assignment to a taxon).</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/terms/"/>
+        <rdfs:label xml:lang="en">Identification</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://rs.tdwg.org/dwc/terms/LivingSpecimen -->
 
-    <owl:Class rdf:about="&dwc;LivingSpecimen">
-        <rdfs:label xml:lang="en">Living Specimen</rdfs:label>
+    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/LivingSpecimen">
         <rdfs:subClassOf rdf:resource="http://purl.org/dsw/Specimen"/>
-        <rdfs:comment xml:lang="en">A specimen that is alive.</rdfs:comment>
         <dc:description xml:lang="en">Definition taken from Darwin Core vocabulary 2014-11-21.</dc:description>
+        <rdfs:comment xml:lang="en">A specimen that is alive.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/terms/"/>
+        <rdfs:label xml:lang="en">Living Specimen</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://rs.tdwg.org/dwc/terms/Occurrence -->
 
-    <owl:Class rdf:about="&dwc;Occurrence">
-        <rdfs:label xml:lang="en">Occurrence</rdfs:label>
-        <owl:disjointWith rdf:resource="&dwc;Organism"/>
-        <owl:disjointWith rdf:resource="&dwc;Taxon"/>
-        <owl:disjointWith rdf:resource="&tc;TaxonConcept"/>
-        <owl:disjointWith rdf:resource="&foaf;Agent"/>
-        <owl:disjointWith rdf:resource="&foaf;Document"/>
-        <rdfs:comment xml:lang="en">An existence of an Organism (sensu http://rs.tdwg.org/dwc/terms/Organism) at a particular place at a particular time.</rdfs:comment>
+    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/Occurrence">
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Organism"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Taxon"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <dc:description xml:lang="en">Definition taken from Darwin Core vocabulary 2014-11-21.</dc:description>
+        <rdfs:comment xml:lang="en">An existence of an Organism (sensu http://rs.tdwg.org/dwc/terms/Organism) at a particular place at a particular time.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/terms/"/>
+        <rdfs:label xml:lang="en">Occurrence</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://rs.tdwg.org/dwc/terms/Organism -->
 
-    <owl:Class rdf:about="&dwc;Organism">
-        <rdfs:label xml:lang="en">Organism</rdfs:label>
-        <owl:disjointWith rdf:resource="&dwc;Taxon"/>
-        <owl:disjointWith rdf:resource="&tc;TaxonConcept"/>
-        <owl:disjointWith rdf:resource="&foaf;Document"/>
-        <rdfs:comment xml:lang="en">A particular organism or defined group of organisms considered to be taxonomically homogeneous.</rdfs:comment>
+    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/Organism">
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/dwc/terms/Taxon"/>
+        <owl:disjointWith rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <dc:description xml:lang="en">Definition taken from Darwin Core vocabulary 2014-11-21.  Replaces dsw:IndividualOrganism, which is now deprecated.</dc:description>
+        <rdfs:comment xml:lang="en">A particular organism or defined group of organisms considered to be taxonomically homogeneous.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/terms/"/>
+        <rdfs:label xml:lang="en">Organism</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://rs.tdwg.org/dwc/terms/PreservedSpecimen -->
 
-    <owl:Class rdf:about="&dwc;PreservedSpecimen">
-        <rdfs:label xml:lang="en">Preserved Specimen</rdfs:label>
+    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/PreservedSpecimen">
         <rdfs:subClassOf rdf:resource="http://purl.org/dsw/Specimen"/>
-        <rdfs:comment xml:lang="en">A specimen that has been preserved.</rdfs:comment>
         <dc:description xml:lang="en">Definition taken from Darwin Core vocabulary 2014-11-21.</dc:description>
+        <rdfs:comment xml:lang="en">A specimen that has been preserved.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/terms/"/>
+        <rdfs:label xml:lang="en">Preserved Specimen</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://rs.tdwg.org/dwc/terms/Taxon -->
 
-    <owl:Class rdf:about="&dwc;Taxon">
-        <rdfs:label xml:lang="en">Taxon</rdfs:label>
-        <owl:disjointWith rdf:resource="&foaf;Agent"/>
-        <owl:disjointWith rdf:resource="&foaf;Document"/>
-        <rdfs:comment xml:lang="en">A group of organisms (sensu http://purl.obolibrary.org/obo/OBI_0100026) considered by taxonomists to form a homogeneous unit.</rdfs:comment>
+    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/Taxon">
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <dc:description xml:lang="en">Definition taken from Darwin Core vocabulary 2014-11-21.  We feel that this class should be considered to be equivalent to TaxonConcept (name plus accordingTo) in TDWG TCS (http://www.tdwg.org/standards/117/). However, this connection has not been explicitly expressed in the Darwin Core standard.</dc:description>
+        <rdfs:comment xml:lang="en">A group of organisms (sensu http://purl.obolibrary.org/obo/OBI_0100026) considered by taxonomists to form a homogeneous unit.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/dwc/terms/"/>
+        <rdfs:label xml:lang="en">Taxon</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept -->
 
-    <owl:Class rdf:about="&tc;TaxonConcept">
-        <owl:disjointWith rdf:resource="&foaf;Agent"/>
-        <owl:disjointWith rdf:resource="&foaf;Document"/>
-        <owl:deprecated rdf:datatype="&xsd;boolean">true</owl:deprecated>
+    <owl:Class rdf:about="http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept">
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <dc:description xml:lang="en">A taxon concept class (name plus accordingTo) considered to be equivalent to TaxonConcept in TDWG TCS (http://www.tdwg.org/standards/117/).  This class was deprecated in favor of the Darwin Core class dwc:Taxon after the dwc:Taxon definition was clarified on 2014-10-26.  Additionally, by that date the TDWG Ontologies (from which this term was taken) were effectively deprecated.</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#"/>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
 
     <!-- http://www.w3.org/2002/07/owl#Thing -->
 
-    <owl:Class rdf:about="&owl;Thing"/>
+    <owl:Class rdf:about="http://www.w3.org/2002/07/owl#Thing"/>
     
 
 
     <!-- http://xmlns.com/foaf/0.1/Agent -->
 
-    <owl:Class rdf:about="&foaf;Agent">
-        <rdfs:label xml:lang="en">Agent</rdfs:label>
-        <owl:disjointWith rdf:resource="&foaf;Document"/>
-        <rdfs:comment xml:lang="en">An agent (eg. person, group, software or physical artifact).</rdfs:comment>
+    <owl:Class rdf:about="http://xmlns.com/foaf/0.1/Agent">
+        <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <dc:description xml:lang="en">Definition taken from FOAF vocabulary 2014-11-21. See also http://purl.org/dc/terms/Agent</dc:description>
+        <rdfs:comment xml:lang="en">An agent (eg. person, group, software or physical artifact).</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+        <rdfs:label xml:lang="en">Agent</rdfs:label>
     </owl:Class>
     
 
 
     <!-- http://xmlns.com/foaf/0.1/Document -->
 
-    <owl:Class rdf:about="&foaf;Document">
-        <rdfs:label xml:lang="en">Document</rdfs:label>
-        <rdfs:comment xml:lang="en">A document.</rdfs:comment>
+    <owl:Class rdf:about="http://xmlns.com/foaf/0.1/Document">
         <dc:description xml:lang="en">Definition taken from FOAF vocabulary 2014-11-21. See also http://purl.org/ontology/bibo/Document</dc:description>
+        <rdfs:comment xml:lang="en">A document.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://xmlns.com/foaf/0.1/"/>
+        <rdfs:label xml:lang="en">Document</rdfs:label>
     </owl:Class>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 3.4.2) http://owlapi.sourceforge.net -->
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
 


### PR DESCRIPTION
Well, I perhaps should have just edited this in a code editor instead of Protege because it made a ton of changes to the file. Mostly it got rid of the entity declarations at the top and just replaced the entities in the doc with absolute URLs. I actually like that better, so I guess this is OK as long as we trust that Protege didn't actually change anything other than adding the license and updating the version information.