### PR TITLE
Adding missing rdfs:label statements

### DIFF
--- a/dsw.owl
+++ b/dsw.owl
@@ -204,6 +204,7 @@
         <dc:creator>Steve Baskauf</dc:creator>
         <dc:description xml:lang="en">Was georeferenceByURI; deprecated 2014-11-21 to be replaced by dwciri:georeferencedBy</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Georeferenced By</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
@@ -296,6 +297,7 @@
         <dc:creator>Steve Baskauf</dc:creator>
         <dc:description xml:lang="en">was dsw:identificationByURI; deprecated 2014-11-21 to be replaced by dwciri:identifiedBy</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Identified By</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
@@ -391,6 +393,7 @@
         <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <dc:description xml:lang="en">Deprecated 2014-11-21 to be replaced by dwciri:recordedBy</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Recorded By</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
@@ -421,6 +424,7 @@
         <dc:creator>Steve Baskauf, name changed by Cam Webb</dc:creator>
         <dc:description xml:lang="en">The toTaxon relationship is many-to-one (many identifications can reference one taxon).  This property should link to a taxon concept (i.e. Taxon name plus Authority) URI, such as: http://biodiversity.org.au/apni.taxon/118883 ; deprecated 2014-11-21 to be replaced by dwciri:toTaxon</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">To Taxon</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:ObjectProperty>
     
@@ -500,6 +504,7 @@
         <dc:creator>Steve Baskauf</dc:creator>
         <dc:description xml:lang="en">Deprecated in favor of dwc:organismRemarks on 2014-11-21.</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Individual Organism Remarks</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
     

--- a/dsw.owl
+++ b/dsw.owl
@@ -490,7 +490,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Data properties
-    //
+    // 
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
@@ -507,7 +507,7 @@
         <rdfs:label xml:lang="en">Individual Organism Remarks</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:DatatypeProperty>
-    
+
 
 
     <!-- http://www.w3.org/2002/07/owl#topDataProperty -->
@@ -566,6 +566,7 @@
         <dc:description xml:lang="en">This class is equivalent to the more well-known Darwin Core class dwc:Organism.  It was deprecated following the addition of dwc:Organism to Darwin Core on 2014-10-26.  </dc:description>
         <rdfs:comment xml:lang="en">A particular organism or defined group of organisms considered to be taxonomically homogeneous.  Instances of the Organism class are intended to facilitate linking of one or more Identification instances to one or more Occurrence instances.  Therefore, things that are typically assigned scientific names (such as viruses, hybrids, and lichens) and aggregates whose occurrences are typically recorded (such as packs, clones, and colonies) are included in the scope of this class.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Individual Organism</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
@@ -578,6 +579,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.org/dsw/Specimen"/>
         <dc:description xml:lang="en">Deprecated in favor of the Darwin Core class dwc:LivingSpecimen.</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Living Specimen</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
@@ -589,6 +591,7 @@
         <rdfs:subClassOf rdf:resource="http://purl.org/dsw/Specimen"/>
         <dc:description xml:lang="en">Deprecated in favor of the Darwin Core class dwc:PreservedSpecimen.</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://purl.org/dsw/"/>
+        <rdfs:label xml:lang="en">Preserved Specimen</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
@@ -746,6 +749,7 @@
         <owl:disjointWith rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
         <dc:description xml:lang="en">A taxon concept class (name plus accordingTo) considered to be equivalent to TaxonConcept in TDWG TCS (http://www.tdwg.org/standards/117/).  This class was deprecated in favor of the Darwin Core class dwc:Taxon after the dwc:Taxon definition was clarified on 2014-10-26.  Additionally, by that date the TDWG Ontologies (from which this term was taken) were effectively deprecated.</dc:description>
         <rdfs:isDefinedBy rdf:resource="http://rs.tdwg.org/ontology/voc/TaxonConcept#"/>
+        <rdfs:label xml:lang="en">Taxon Concept</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     


### PR DESCRIPTION
A few years ago DSW was loaded to AgroPortal: 
http://agroportal.lirmm.fr/ontologies/DSW

In February 2021 it seems DSW has been updated by automatic pulling content from: 
https://raw.githubusercontent.com/darwin-sw/dsw/master/dsw.owl

We have a recurrent issues showing that DSW is well parsed but no fully searchable in AgroPortal. 

I have briefly checked and notice some classes do not have any label at all: 
```
<!-- http://purl.org/dsw/PreservedSpecimen -->
<!-- http://purl.org/dsw/IndividualOrganism —>
<!-- http://purl.org/dsw/LivingSpecimen —>
<!-- http://rs.tdwg.org/ontology/voc/TaxonConcept#TaxonConcept —>
```

This PR fixes this in 2 steps:
- adding missing labels to properties 
- adding missing labels to classes

First commit (properties) is optional if the main developer does not want to have duplicate labels for 2 different classes in the ontology e.g., 
```
<!-- http://purl.org/dsw/georefBy -->
<!-- http://rs.tdwg.org/dwc/iri/georeferencedBy -->
```
The presence of duplicate properties is another issue. 

